### PR TITLE
【Fixed】'rails g'コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,19 +1,20 @@
 require_relative 'boot'
-
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Saver
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
#1 
デフォルトで helper と assets ファイルが生成されないようにする
